### PR TITLE
ci: fail on ESLint warnings (--max-warnings=0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,4 @@ npm run dev
 _This starts the server in non-database mode._ It will serve a simple webpage at `http://localhost:8080`.
 
 You do _not_ need to set up a database or any interactivity on the webpage yet. Instructions for that will come later in the course!
+


### PR DESCRIPTION
Purpose
- Enforce ESLint warnings as failures in CI for security/style checks.

Changes
- Update workflow to run: `npm run lint -- --max-warnings=0`
- (Plus a tiny no-op commit to trigger CI on this PR.)

Expected result
- The PR’s GitHub Actions run should FAIL at the Lint step (on purpose) because warnings exist. This is required by the Boot.dev assignment.

Notes
- No application code changes.
